### PR TITLE
Do not use argparse options when using project as sumpbomude

### DIFF
--- a/track.py
+++ b/track.py
@@ -118,7 +118,7 @@ def run(
 
     # initialize StrongSORT
     cfg = get_config()
-    cfg.merge_from_file(opt.config_strongsort)
+    cfg.merge_from_file(config_strongsort)
 
     # Create as many strong sort instances as there are video sources
     strongsort_list = []


### PR DESCRIPTION
TO have an ability to call `run()` method from code, but not from terminal