### PR TITLE
fix: take stride as numpy from model in track.py

### DIFF
--- a/reid_export.py
+++ b/reid_export.py
@@ -17,7 +17,8 @@ if str(ROOT / 'strong_sort') not in sys.path:
     sys.path.append(str(ROOT / 'strong_sort/'))  # add strong_sort ROOT to PATH
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-from yolov5.utils.general import LOGGER, colorstr
+from yolov7.utils.general import colorstr
+from yolov7.utils.add_nms import LOGGER
 from strong_sort.deep.reid.torchreid.utils.feature_extractor import FeatureExtractor
 from strong_sort.deep.reid.torchreid.models import build_model
 from strong_sort.deep.reid_model_factory import get_model_name

--- a/track.py
+++ b/track.py
@@ -102,14 +102,14 @@ def run(
     WEIGHTS.mkdir(parents=True, exist_ok=True)
     model = attempt_load(Path(yolo_weights), map_location=device)  # load FP32 model
     names, = model.names,
-    stride = model.stride.max()  # model stride
-    imgsz = check_img_size(imgsz[0], s=stride.cpu().numpy())  # check image size
+    stride = model.stride.max().cpu().numpy()  # model stride
+    imgsz = check_img_size(imgsz[0], s=stride)  # check image size
 
     # Dataloader
     if webcam:
         show_vid = check_imshow()
         cudnn.benchmark = True  # set True to speed up constant image size inference
-        dataset = LoadStreams(source, img_size=imgsz, stride=stride.cpu().numpy())
+        dataset = LoadStreams(source, img_size=imgsz, stride=stride)
         nr_sources = 1
     else:
         dataset = LoadImages(source, img_size=imgsz, stride=stride)


### PR DESCRIPTION
Hi!
Trying to solve issue #38, but in #2 it seems solved (seems like one of the solutions was to edit PyTorch sources - which is weird solution) and other solution was to cast `stride` from model to int/numpy-scalar.
For Streams - numpy is expected, but for Images loader - Tensor, which is cause inconsistency between methods. 
In order current solution to work, also [send request for yolo7](https://github.com/mikel-brostrom/yolov7/pull/2) repo where all operation with stride (and produced from it object) must be via numpy, not PyTorch.